### PR TITLE
Replace getClientSize() method with getSize()

### DIFF
--- a/src/Database/Attach/MediaAdder.php
+++ b/src/Database/Attach/MediaAdder.php
@@ -120,7 +120,7 @@ class MediaAdder
         if ($file instanceof UploadedFile) {
             $media->file_name = $file->getClientOriginalName();
             $media->mime_type = $file->getMimeType();
-            $media->size = $file->getClientSize();
+            $media->size = $file->getSize();
             $this->pathToFile = $file->getPath().DIRECTORY_SEPARATOR.$file->getFilename();
         }
 


### PR DESCRIPTION
Accordling with Symfony http foundation changelog from version 5.0.0 the method UploadedFile::getClientSize() has been removed, now we have to use UploadedFile::getClient() instead